### PR TITLE
OpenBSD pledge(2) and unveil(2) support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ are made.
     -L text|file  Set or load server location for caps.txt
     -A admin      Set admin email for caps.txt
 
+    -U paths      Specify a colon-separated list of extra unveil(2) paths
+                  (OpenBSD only).
+
     -nv           Disable virtual hosting
     -nl           Disable parent directory links
     -nh           Disable menu header (title)
@@ -107,6 +110,32 @@ simply hidden from all listings and denied if a client asks for them.
 The `-nx` option prevents execution of any script or external file,
 and the `-nu` option suppresses scanning for and serving of `~user`
 directories (which are normally at `~/public_html/` for each user).
+
+### OpenBSD-specific Security
+
+If you are running Gophernicus on OpenBSD, you may (depending on what features
+you want to use) be able to take advantage of unveil(2) and pledge(2).
+
+If you run without executable map support (i.e. you run with `-nx`) then
+unveil(2) will be enabled and the server root will automatically be unveiled.
+If run with personal gopherspaces enabled (i.e. you run without `-nu`), then
+the password database (`/etc/pwd.db`) will automatically be unveiled, but you
+will have to manually unveil the filesystem path(s) from which to serve
+personal gopherspaces (see `-U`).
+
+Running with `-nm -nu -nx` results in the strictest set of pledge(2) promises.
+If you have executable maps enabled (i.e. you run without `-nx`), then the
+promises are relaxed to allow `exec`. If you have personal gopherspaces enabled
+(i.e. you run without `-nu`), then the promises are relaxed to allow `getpw`.
+If you have shared memory enabled (i.e. you run without `-nm`), then pledge(2)
+support cannot be used at all.
+
+In short, you probably want to  run Gophernicus with `-nm -nu -nx` and then
+remove the flags that would otherwise disable the features you want.
+
+To see what is going on with regards to pledge(2) and unveil(2), run
+Gophernicus with `-d` (to turn on debug logging) and look in your system logs.
+
 
 ## Gophermaps
 

--- a/gophernicus.h
+++ b/gophernicus.h
@@ -342,6 +342,10 @@ typedef struct {
     srewrite rewrite[MAX_REWRITE];
     int rewrite_count;
 
+#ifdef __OpenBSD__
+	char *extra_unveil_paths;
+#endif
+
     /* Session */
     int session_timeout;
     int session_max_kbytes;

--- a/options.c
+++ b/options.c
@@ -101,7 +101,11 @@ void parse_args(state *st, int argc, char *argv[])
     int opt;
 
     /* Parse args */
-    while ((opt = getopt(argc, argv, "h:p:T:r:t:g:a:c:u:m:l:w:o:s:i:k:f:e:R:D:L:A:P:n:dbv?-")) != ERROR) {
+    while ((opt = getopt(argc, argv,
+#ifdef __OpenBSD__
+        "U:" /* extra unveil(2) paths are OpenBSD only */
+#endif
+        "h:p:T:r:t:g:a:c:u:m:l:w:o:s:i:k:f:e:R:D:L:A:P:n:dbv?-")) != ERROR) {
         switch(opt) {
             case 'h': sstrlcpy(st->server_host, optarg); break;
             case 'p': st->server_port = atoi(optarg); break;
@@ -133,7 +137,9 @@ void parse_args(state *st, int argc, char *argv[])
             case 'D': sstrlcpy(st->server_description, optarg); break;
             case 'L': sstrlcpy(st->server_location, optarg); break;
             case 'A': sstrlcpy(st->server_admin, optarg); break;
-
+#ifdef __OpenBSD__
+            case 'U': st->extra_unveil_paths = optarg; break;
+#endif
             case 'n':
                 if (*optarg == 'v') { st->opt_vhost = FALSE; break; }
                 if (*optarg == 'l') { st->opt_parent = FALSE; break; }


### PR DESCRIPTION
Please don't merge this until another OpenBSD developer has checked my work.

This diff improves the security of Gophernicus when used on OpenBSD via `pledge(2)` and `unveil(2)`.

For more info on these APIs:
 * https://man.openbsd.org/pledge
 * https://man.openbsd.org/unveil

The only minor nit I have with my work is that we lose the ability to unveil if personal gopherspaces are enabled. The reason for this is that user homes are arbitrary paths, so simply unveiling `/home` wouldn't be right. We could add a switch which allows the user to specify which directories to unveil(2)... Not sure if it's worth it though and we already have so many switches.

Thanks