### PR TITLE
Allowing irc:// as safe redirect in file.c

### DIFF
--- a/file.c
+++ b/file.c
@@ -110,6 +110,7 @@ void url_redirect(state *st)
 	if (sstrncmp(dest, "http://") != MATCH &&
 	    sstrncmp(dest, "https://") != MATCH &&
 	    sstrncmp(dest, "ftp://") != MATCH &&
+	    sstrncmp(dest, "irc://") != MATCH &&
 	    sstrncmp(dest, "mailto:") != MATCH)
 		die(st, ERR_ACCESS, "Refusing to HTTP redirect unsafe protocols");
 


### PR DESCRIPTION
Per [issue 27](https://github.com/gophernicus/gophernicus/issues/27), I added `irc://` as an allowed protocol for redirects in `file.c`