### PR TITLE
add a warning for development branch

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,13 +5,17 @@ from standard LIBC ones. Care has been taken to use only
 standard POSIX syscalls so that it should work pretty much on
 any \*nix system.
 
+Please make sure that you checkout to the correct version you want.
+Currently, you most likely want version 3.0.
+
 To compile and install run:
 
 ```
 $ git clone https://github.com/gophernicus/gophernicus.git
 $ cd gophernicus
+$ git checkout 3.0
 $ make
-$ sudo make install
+# make install
 ```
 
 That's it - Gophernicus should now be installed, preconfigured
@@ -27,10 +31,7 @@ the gopher root and make sure you have at least the primary
 hostname (the one set with `-h <hostname>`) directory available
 (`mkdir /var/gopher/$HOSTNAME`).
 
-
-<<<<<<< HEAD:INSTALL
-Dependencies
-============
+## Dependencies
 
 These were obtained from a base docker installation, what we
 (will) be using on Travis.
@@ -66,17 +67,12 @@ These were obtained from a base docker installation, what we
 # Alpine Linux #
 - alpine-sdk. once again, less is probably required.. blah blah.
 
-Other installation targets
-==========================
-=======
 ## Other installation targets
->>>>>>> 82a1abebc4bfabc43ef6b27f0627f526984eaf30:INSTALL.md
 
 Suppose your server runs systemd, but you'd rather have Gophernicus
 started with inetd or xinetd.  To do that, do `make install-inetd`
 or `make install-xinetd`.  Likewise use `make uninstall-inetd` or
 `make uninstall-xinetd` to uninstall Gophernicus.
-
 
 ## Compiling with TCP wrappers
 
@@ -93,7 +89,6 @@ at the files `/etc/hosts.allow` and `/etc/hosts.deny` (because the
 manual pages suck). Use the daemon name 'gophernicus' to
 make your access lists.
 
-
 ## Running with traditional inetd superserver
 
 If you want to run Gophernicus under the traditional Unix inetd, the 
@@ -106,7 +101,6 @@ gopher  stream  tcp  nowait  nobody  /usr/sbin/gophernicus  gophernicus -h <host
 
 The Makefile will automatically do this for you and remove it when
 uninstalling.
-
 
 ## Compiling on Debian Linux (and Ubuntu)
 
@@ -122,7 +116,6 @@ Work(tm).
 If you need TCP wrappers support on Debian/Ubuntu, please
 install libwrap0-dev before compiling.
 
-
 ## Cross-compiling
 
 Cross-compiling to a different target architecture can be done
@@ -134,9 +127,7 @@ arch one.
 $ make HOSTCC=gcc CC=target-arch-gcc
 ```
 
-
 ## Shared memory issues
-====================
 
 Gophernicus uses SYSV shared memory for session tracking and
 statistics. It creates the shared memory block using mode 600
@@ -153,7 +144,6 @@ let Gophernicus recreate it - no harm done:
 $ sudo make clean-shm
 ```
 
-
 ## Porting to different platforms
 
 If you need to port Gophernicus to a new platform, please take
@@ -164,9 +154,7 @@ platform please send the patches to
 <gophernicus at gophernicus dot org> so we can include them into
 the next release.
 
-<<<<<<< HEAD:INSTALL
-Supported Platforms
-===================
+# Supported Platforms
 
 | Platform     | Versions                     |
 | ------------ | ---------------------------- |
@@ -178,5 +166,3 @@ Supported Platforms
 | Arch Linux   | up to date                   |
 | Gentoo       | up to date                   |
 | Alpine Linux | Edge, 3.9                    |
-=======
->>>>>>> 82a1abebc4bfabc43ef6b27f0627f526984eaf30:INSTALL.md

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,15 @@
 #
 # Variables and default configuration
 #
-NAME     = gophernicus
-PACKAGE  = $(NAME)
-BINARY   = $(NAME)
-VERSION  = 3.0 
-CODENAME = Dungeon Edition
-AUTHOR   = h9bnks and fosslinux
-EMAIL    = gophernicus@gophernicus.org
-STARTED  = 2009
+NAME        = gophernicus
+PACKAGE     = $(NAME)
+BINARY      = $(NAME)
+VERSION     = 3.0 
+CODENAME    = Dungeon Edition
+AUTHOR      = h9bnks and fosslinux
+EMAIL       = gophernicus@gophernicus.org
+STARTED     = 2009
+DEVELOPMENT = 1
 
 SOURCES = $(NAME).c file.c menu.c string.c platform.c session.c options.c
 HEADERS = functions.h files.h
@@ -132,6 +133,10 @@ clean-shm:
 # Install targets
 #
 install: clean-shm
+	@if [ ${DEVELOPMENT} -ne 0 ] ; then \
+		printf "This is the development version, here be fiery dragons, are you sure you want to continue?\\n" ;\
+		printf "Press ctrl-c to exit now, or enter if you are sure you want to continue.\\n" ;\
+		read DEV_WARNING ; fi
 	@case `uname` in \
 		Darwin)  $(MAKE) ROOT="$(OSXROOT)" DESTDIR="$(OSXDEST)" install-files install-docs install-root install-osx install-done; ;; \
 		Haiku)   $(MAKE) SBINDIR=/boot/common/bin DOCDIR=/boot/common/share/doc/$(PACKAGE) \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Gophernicus
 
-Version 3.0
+Development! DO NOT USE unless you want fiery dragons!
+(you probably want to `git checkout 3.0`)
 
 *Copyright (c) 2009-2019 Kim Holviala and others*
 
 Gophernicus is a modern full-featured (and hopefully) secure gopher
 daemon. It is licensed under the BSD license.
+
+(If you are looking for installation documentation, please see INSTALL.md).
 
 ## Support/Contact
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -2,10 +2,15 @@
 
 ## Latest version
 
-3.0
+3.0.1
 
 ## Changelog
 <!--- this should be mirrored from Changelog -->
+
+### 3.0.1
+
+ * update documentation to `git checkout` before install
+ * fix typo in docs for debian packaging
 
 ### 3.0 (from 101):
 **N.B. this version has two important changes that may make it backwards-incompatible:**

--- a/changelog
+++ b/changelog
@@ -1,3 +1,9 @@
+3.0.1
+=====
+
+ * add installation notes to git checkout before installing
+ * fix typo in debian packaging
+
 3.0 (from 101)
 ==============
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,8 @@
+gophernicus (3.0.1-1) unstable; urgency=medium
+
+  * add installation notes to git checkout before installing
+  * fix typo in debian packaging
+
 gophernicus (3.0-1.1) unstable; urgency=medium
 
   * N.B. this version has two important changes that may make it

--- a/debian/docs
+++ b/debian/docs
@@ -2,6 +2,6 @@ README.md
 README.Gophermap
 TODO
 INSTALL.md
-VERSONING.md
+VERSIONING.md
 changelog
 gophertag


### PR DESCRIPTION
We don't want users to accidentally install the `master`, or development branch. Add a warning in `make install` to warn them of this.