### PR TITLE
replace executable name, remove trailing spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.o
 files.h
 functions.h
+README
 README.options
 bin2c
 gophernicus

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -14,11 +14,19 @@ $ make
 $ sudo make install
 ```
 
+after having set the correct public hostname in the `gophernicus.env`
+file. If this is wrong, selectors ("gopher links") won't work!
+
+On \*nix systems, `hostname` might give you an idea, but please
+note this might be completely wrong, especially on your personal
+machine at home or on some cheap virtual server. If you know you
+have a fixed numerical IP, you can also directly use that.
+For testing, just keep the default value of `localhost` which will
+result in selectors working only when you're connecting locally.
+
 That's it - Gophernicus should now be installed, preconfigured
 and running under gopher://<HOSTNAME>/. And more often than not,
-It Just Works(tm). If gopher links don't seem to work you may
-need to configure your public hostname explicitly in whatever
-config file Gophernicus is using.
+It Just Works(tm).
 
 By default Gophernicus serves gopher documents from `/var/gopher`
 although that can be changed by using the `-r <root>` parameter.
@@ -28,49 +36,43 @@ hostname (the one set with `-h <hostname>`) directory available
 (`mkdir /var/gopher/$HOSTNAME`).
 
 
-<<<<<<< HEAD:INSTALL
-Dependencies
-============
+## Dependencies
 
 These were obtained from a base docker installation, what we
 (will) be using on Travis.
 
-# Ubuntu 18.04, 16.04, Debian Sid, Buster, Stretch, Jessie #
+### Ubuntu 18.04, 16.04, Debian Sid, Buster, Stretch, Jessie
 - build-essential
 - git
 - libwrap0-dev for tcp
 
-# Centos 6, 7 #
+### Centos 6, 7
 - the group 'Development Tools'. less is probably required, but
   I know this works and couldn't be bothered to find out what was
   actually required.
 
-# Fedora 29, 30, rawhide #
+### Fedora 29, 30, rawhide
 - the group 'Development Tools'. less is probably required, but
   I know this works and couldn't be bothered to find out what was
   actually required.
 - net-tools
 
-# OpenSuse Leap, Tumbleweed #
+### OpenSuse Leap, Tumbleweed
 - the pattern devel_C_C++
 - the pattern devel_basis
 - git
 
-# archlinux #
+### archlinux
 - base-devel
 - git
 
-# Gentoo #
+### Gentoo
 - git
 
-# Alpine Linux #
+### Alpine Linux
 - alpine-sdk. once again, less is probably required.. blah blah.
 
-Other installation targets
-==========================
-=======
-## Other installation targets
->>>>>>> 82a1abebc4bfabc43ef6b27f0627f526984eaf30:INSTALL.md
+### Other installation targets
 
 Suppose your server runs systemd, but you'd rather have Gophernicus
 started with inetd or xinetd.  To do that, do `make install-inetd`
@@ -90,14 +92,14 @@ just run 'make withwrap'.
 
 For configuring IP access lists with TCP wrappers, take a look
 at the files `/etc/hosts.allow` and `/etc/hosts.deny` (because the
-manual pages suck). Use the daemon name 'gophernicus' to
+manual pages suck). Use the daemon name "gophernicus" to
 make your access lists.
 
 
 ## Running with traditional inetd superserver
 
-If you want to run Gophernicus under the traditional Unix inetd, the 
-below line should be added to your `/etc/inetd.conf` and the inetd 
+If you want to run Gophernicus under the traditional Unix inetd, the
+below line should be added to your `/etc/inetd.conf` and the inetd
 process restarted.
 
 ```
@@ -134,9 +136,7 @@ arch one.
 $ make HOSTCC=gcc CC=target-arch-gcc
 ```
 
-
 ## Shared memory issues
-====================
 
 Gophernicus uses SYSV shared memory for session tracking and
 statistics. It creates the shared memory block using mode 600
@@ -156,17 +156,14 @@ $ sudo make clean-shm
 
 ## Porting to different platforms
 
-If you need to port Gophernicus to a new platform, please take
-a look at gophernicus.h which has a bunch of `HAVE_*` `#defines`.
-Fiddling with those usually makes it possible to compile a working
-server. If you succeed in compiling Gophernicus to a new
-platform please send the patches to 
-<gophernicus at gophernicus dot org> so we can include them into
-the next release.
+If you need to port Gophernicus to a new platform, please take a look at
+gophernicus.h which has a bunch of `#define HAVE_...` Fiddling with those
+usually makes it possible to compile a working server.
+If you succeed in compiling Gophernicus to a new platform please send
+the patches to <gophernicus at gophernicus dot org> so we can include
+them into the next release.
 
-<<<<<<< HEAD:INSTALL
-Supported Platforms
-===================
+## Supported Platforms
 
 | Platform     | Versions                     |
 | ------------ | ---------------------------- |
@@ -178,5 +175,4 @@ Supported Platforms
 | Arch Linux   | up to date                   |
 | Gentoo       | up to date                   |
 | Alpine Linux | Edge, 3.9                    |
-=======
->>>>>>> 82a1abebc4bfabc43ef6b27f0627f526984eaf30:INSTALL.md
+| FreeBSD      | 12.0                         |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -161,7 +161,8 @@ gophernicus.h which has a bunch of `#define HAVE_...` Fiddling with those
 usually makes it possible to compile a working server.
 If you succeed in compiling Gophernicus to a new platform please send
 the patches to <gophernicus at gophernicus dot org> so we can include
-them into the next release.
+them into the next release -- or even better, commit them to your fork
+on Github and make a pull request!
 
 ## Supported Platforms
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 NAME     = gophernicus
 PACKAGE  = $(NAME)
 BINARY   = $(NAME)
-VERSION  = 3.0 
+VERSION  = 3.0
 CODENAME = Dungeon Edition
 AUTHOR   = h9bnks and fosslinux
 EMAIL    = gophernicus@gophernicus.org

--- a/README.Gophermap
+++ b/README.Gophermap
@@ -10,7 +10,7 @@ file. You can also have inline gophermaps - files with a ".gophermap"
 extension are parsed as gophermaps and displayed in between normal
 resources in alphabetical order.
 
-In a gophermap any line that doesn't contain a <TAB> character is 
+In a gophermap any line that doesn't contain a <TAB> character is
 automatically converted to an type "i" gopher resource which are
 displayed as plain text in the client. Lines which contain tabs are
 intepreted as gopher resource lines which the client will render as
@@ -63,7 +63,7 @@ Additional type characters supported by Gophernicus:
    :ext=type  change filetype (for this directory only)
    ~          include a list of users with valid ~/public_gopher
    %          include a list of available virtual hosts
-   =mapfile   include or execute other gophermap 
+   =mapfile   include or execute other gophermap
    *          stop processing gophermap, include file listing
    .          stop processing gophermap (default)
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ way to fix this.
 
 It is recommended to add '%' on a line by itself to the bottom of your root
 gophermaps. This will add "special" links of the format example.com/;example.com
-which forces the correct vhost. 
+which forces the correct vhost.
 
 ## CGI support
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -5,15 +5,18 @@
 3.0
 
 ## Changelog
+
 <!--- this should be mirrored from Changelog -->
 
 ### 3.0 (from 101):
-**N.B. this version has two important changes that may make it backwards-incompatible:**
- * binary changed from in.gophernicus to gophernicus
- * virtual hosting NEVER WORKED and does not work in the way previously
-   described
 
-Other changes:
+**N.B. this version has two important changes that may make it backwards-incompatible:**
+
+ * binary changed from in.gophernicus to gophernicus
+ * virtual hosting NEVER WORKED and does not work in the way previously described
+
+#### Other changes:
+
  * prevent leak of executable gophermap contents
  * make sure {x,}inetd works when systemd is on the system
  * allow -j flag to work
@@ -31,10 +34,10 @@ Other changes:
  * add travis ci
  * add documentation about CI
 
-Upgrade guide:
+#### Upgrade guide:
 
-If you are running gophernicus on a **production** system, **do not** upgrade 
-to 3.0. Wait for 3.1.
+If you are running gophernicus on a **production** system, **do not** upgrade to 3.0.
+Wait for 3.1.
 
 As a general guide:
 
@@ -50,6 +53,6 @@ Gophernicus has had a rough versioning history.
 Versions progressed through to 2.6. Then it changed to a rolling-release scheme.
 This dosen't work very well, hence the decision was made to revert to a numbered
 versioning scheme. In some places, it was referred to 101 (the git commit
-number) or 2.99.101 (2.99.gitcommitnumber). 
+number) or 2.99.101 (2.99.gitcommitnumber).
 
 These days (June 2019), the vast majority of gophernicus servers are on 101.

--- a/changelog
+++ b/changelog
@@ -1,13 +1,13 @@
 3.0 (from 101)
 ==============
 
-N.B. this version has two important changes that may make it
-backwards-incompatible:
+N.B. this version has two important changes that may make it backwards-incompatible:
+
  * binary changed from in.gophernicus to gophernicus
- * virtual hosting NEVER WORKED and does not work in the way previously
-   described
+ * virtual hosting NEVER WORKED and does not work in the way previously described
 
 Other changes:
+
  * prevent leak of executable gophermap contents
  * make sure {x,}inetd works when systemd is on the system
  * allow -j flag to work
@@ -27,10 +27,10 @@ Other changes:
 
 Upgrade guide:
 
-If you are running gophernicus on a **production** system, **do not** upgrade
-to 3.0. Wait for 3.1.
+If you are running gophernicus on a **production** system, **do not** upgrade to 3.0.
+Wait for 3.1.
 
-As a general guide,
+As a general guide:
 
 If you are running 101 and haven't upgraded to newer versions **because** of
 instability worries, **wait for 3.1**.

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: gophernicus
 Section: net
 Priority: extra
-Maintainer: gophernicus developers <gophernicus@gophernicus.org> 
+Maintainer: gophernicus developers <gophernicus@gophernicus.org>
 Build-Depends: debhelper (>= 5), libwrap0-dev
 Standards-Version: 3.7.3
 Homepage: https://github.com/gophernicus/gophernicus

--- a/debian/gophernicus.templates
+++ b/debian/gophernicus.templates
@@ -1,4 +1,4 @@
 Template: gophernicus/fqdn
 Type: string
-Default: 
+Default:
 Description: Fully-qualified hostname for the gopher server:

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ -f /etc/inetd.conf -a -x /usr/sbin/update-inetd ]; then
-	/usr/sbin/update-inetd --disable gopher 
+	/usr/sbin/update-inetd --disable gopher
 fi
 
 if [ -x /usr/bin/deb-systemd-helper ]; then

--- a/debian/rules
+++ b/debian/rules
@@ -23,19 +23,19 @@ build-stamp:
 
 	touch $@
 
-clean: 
+clean:
 	dh_testdir
 	dh_testroot
 	rm -f build-stamp
 
 	$(MAKE) clean-build
 
-	dh_clean 
+	dh_clean
 
 install: build
 	dh_testdir
 	dh_testroot
-	dh_clean -k 
+	dh_clean -k
 	dh_installdirs
 
 	# Add here commands to install the package into debian/gophernicus

--- a/gophernicus.c
+++ b/gophernicus.c
@@ -177,7 +177,7 @@ void log_combined(state *st, int status)
 
 	/* Generate log entry */
 	fprintf(fp, "%s %s:%i - [%s] \"GET %c%s HTTP/1.0\" %i %li \"%s\" \"" HTTP_USERAGENT "\"\n",
-		st->req_remote_addr, 
+		st->req_remote_addr,
 		st->server_host,
 		st->server_port,
 		timestr,

--- a/gophernicus.h
+++ b/gophernicus.h
@@ -1,7 +1,7 @@
 /*
  * Gophernicus - Copyright (c) 2009-2018 Kim Holviala <kimholviala@fastmail.com>
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
  *     * Redistributions of source code must retain the above copyright
@@ -9,7 +9,7 @@
  *     * Redistributions in binary form must reproduce the above copyright
  *       notice, this list of conditions and the following disclaimer in the
  *       documentation and/or other materials provided with the distribution.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE

--- a/gophernicus.xinetd
+++ b/gophernicus.xinetd
@@ -2,7 +2,7 @@
 # description: Gophernicus - Modern full-featured gopher server
 service gopher
 {
-	socket_type	= stream        
+	socket_type	= stream
 	wait		= no
 	user		= nobody
 	server		= /usr/sbin/gophernicus

--- a/menu.c
+++ b/menu.c
@@ -179,7 +179,7 @@ void vhostlist(state *st)
 			strftime(timestr, sizeof(timestr), DATE_FORMAT, ltime);
 
 			printf("1%-*.*s   %s        -  \t/;%s\t%s\t%i" CRLF,
-				width, width, buf, timestr, dir[i].name, 
+				width, width, buf, timestr, dir[i].name,
 				dir[i].name, st->server_port);
 		}
 
@@ -226,7 +226,7 @@ char gopher_filetype(state *st, char *file, char magic)
 	fclose(fp);
 
 	/* GIF images */
-	if (sstrncmp(buf, "GIF89a") == MATCH || 
+	if (sstrncmp(buf, "GIF89a") == MATCH ||
 	    sstrncmp(buf, "GIF87a") == MATCH) return TYPE_GIF;
 
 	/* JPEG images */
@@ -405,7 +405,7 @@ int gophermap(state *st, char *mapfile, int depth)
 		/* Parse port */
 		port = st->server_port;
 		if ((c = strchr(host, '\t'))) {
-			*c = '\0'; 
+			*c = '\0';
 			port = atoi(c + 1);
 		}
 

--- a/options.c
+++ b/options.c
@@ -151,7 +151,7 @@ void parse_args(state *st, int argc, char *argv[])
 			case 'd': st->debug = TRUE; break;
 			case 'b': puts(license); exit(EXIT_SUCCESS);
 
-			case 'v': 
+			case 'v':
 				printf("%s/%s \"%s\" (built %s)\n", SERVER_SOFTWARE, VERSION, CODENAME, __DATE__);
 				exit(EXIT_SUCCESS);
 

--- a/platform.c
+++ b/platform.c
@@ -274,7 +274,7 @@ void platform(state *st)
 #else
 	         release,
 	         machine);
-#endif 
+#endif
 
 	/* Debug */
 	if (st->debug) {


### PR DESCRIPTION
Fine with 3.0 -- here are just some small corrections and suggestions for reformatting, replacing "in.gophernicus" by "gophernicus" at several spots, as well as removals of trailing spaces and spurious cruft from old commits.
I've also added better explanation of hostname setting and noticed FreeBSD 12 as supported (because it runs well with inetd on several of my machines).