### PR TITLE
change default charset to utf-8

### DIFF
--- a/gophernicus.h
+++ b/gophernicus.h
@@ -215,7 +215,7 @@ size_t strlcat(char *dst, const char *src, size_t siz);
 #define DEFAULT_CGI		"/cgi-bin/"
 #define DEFAULT_USERDIR		"public_gopher"
 #define DEFAULT_WIDTH       67	
-#define DEFAULT_CHARSET		US_ASCII
+#define DEFAULT_CHARSET		UTF_8
 #define MIN_WIDTH		33
 #define MAX_WIDTH		200
 #define UNKNOWN_ADDR		"unknown"

--- a/options.c
+++ b/options.c
@@ -118,6 +118,7 @@ void parse_args(state *st, int argc, char *argv[])
             case 'w': st->out_width = atoi(optarg); break;
             case 'o':
                 if (sstrncasecmp(optarg, "UTF-8") == MATCH) st->out_charset = UTF_8;
+                if (sstrncasecmp(optarg, "US-ASCII") == MATCH) st->out_charset = US_ASCII;
                 if (sstrncasecmp(optarg, "ISO-8859-1") == MATCH) st->out_charset = ISO_8859_1;
                 break;
 


### PR DESCRIPTION
These days, the vast majority of gopher servers and clients run using UTF-8. Let's change the default charset to utf-8, so that people can use Unicode characters easily and without modification to the options.

@hb9kns 