### PR TITLE
ci: New Travis system for linux and macOS builds and installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,19 @@
+language: c
+group: travis_latest
 dist: bionic
 
-language: c
+git:
+  depth: false
+  quiet: true
+
+os:
+  - linux
+  - osx
+  
 compiler:
-  - gcc
   - clang
+  - gcc
+
+script:
+  - make
+  - sudo make install


### PR DESCRIPTION
Working and tested .travis.yml for gophernicus.

It complies the src/ on Linux and macOS with gcc and clang. After this it runs `sudo make install`