### PR TITLE
build: Force create symlink & travis build fix on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ install-root:
 	if [ ! -d "$(ROOT)" -o ! -f "$(ROOT)/$(MAP)" ]; then \
 		mkdir -p $(ROOT); \
 		$(INSTALL) -m 644 $(MAP).sample $(ROOT); \
-		ln -s $(DOCDIR) $(ROOT)/docs; \
+		ln -fs $(DOCDIR) $(ROOT)/docs; \
 	fi
 	@echo
 

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ IPCRM   = /usr/bin/ipcrm
 
 all:
 	@case `uname` in \
-		Darwin)	$(MAKE) ROOT="$(OSXROOT)" DESTDIR="$(OSXDEST)" src/$(BINARY); ;; \
+		Darwin)	$(MAKE) ROOT="$(OSXROOT)" DESTDIR="$(OSXDIr)" src/$(BINARY); ;; \
 		Haiku)	$(MAKE) EXTRA_LIBS="-lnetwork" src/$(BINARY); ;; \
 		*)	if [ -f "/usr/include/tcpd.h" ]; then $(MAKE) withwrap; else $(MAKE) src/$(BINARY); fi; ;; \
 	esac
@@ -104,7 +104,7 @@ clean-shm:
 
 install: clean-shm
 	@case `uname` in \
-		Darwin)  $(MAKE) ROOT="$(OSXROOT)" DESTDIR="$(OSXDEST)" install-files install-docs install-root install-osx install-done; ;; \
+		Darwin)  $(MAKE) ROOT="$(OSXROOT)" DESTDIR="$(OSXDIR)" install-files install-docs install-root install-osx install-done; ;; \
 		Haiku)   $(MAKE) SBINDIR=/boot/common/bin DOCDIR=/boot/common/share/doc/$(PACKAGE) \
 		                 install-files install-docs install-root install-haiku install-done; ;; \
 		*)       $(MAKE) install-files install-docs install-root; ;; \


### PR DESCRIPTION
While working on a new feature I discovered that make returns an error because the documentation symlink already exists. This is not really useful when testing the install feature a lot. This PR force creates the symlink.