### PR TITLE
Add option `-nH` to disable HTTP response to HTTP GET/POST requests (#66)

### DIFF
--- a/gophernicus.1.man
+++ b/gophernicus.1.man
@@ -58,6 +58,7 @@ much more. It is fully FOSS, and licensed under the BSD 2-Clause license.
   -np           Disable HAproxy proxy protocol
   -nx           Disable execution of gophermaps and scripts
   -nu           Disable personal gopherspaces
+  -nH           Disable HTTP response to HTTP GET/POST requests.
 
   -d            Debug output in syslog and /server-status
   -v            Display version number and build date

--- a/src/gophernicus.c
+++ b/src/gophernicus.c
@@ -475,6 +475,7 @@ void init_state(state *st)
 	st->opt_proxy = TRUE;
 	st->opt_exec = TRUE;
 	st->opt_personal_spaces = TRUE;
+	st->opt_http_requests = TRUE;
 	st->debug = FALSE;
 
 	/* Load default suffix -> filetype mappings */
@@ -720,8 +721,9 @@ get_selector:
 	}
 
 	/* Convert HTTP request to gopher (respond using headerless HTTP/0.9) */
-	if (sstrncmp(selector, "GET ") == MATCH ||
-		sstrncmp(selector, "POST ") == MATCH ) {
+	if (st.opt_http_requests && (
+		sstrncmp(selector, "GET ") == MATCH ||
+		sstrncmp(selector, "POST ") == MATCH)) {
 
 		if ((c = strchr(selector, ' '))) sstrlcpy(selector, c + 1);
 		if ((c = strchr(selector, ' '))) *c = '\0';

--- a/src/gophernicus.h
+++ b/src/gophernicus.h
@@ -369,6 +369,7 @@ typedef struct {
     char opt_proxy;
     char opt_exec;
     char opt_personal_spaces;
+    char opt_http_requests;
     char debug;
 } state;
 

--- a/src/options.c
+++ b/src/options.c
@@ -157,6 +157,7 @@ void parse_args(state *st, int argc, char *argv[])
 				if (*optarg == 'p') { st->opt_proxy = FALSE; break; }
 				if (*optarg == 'x') { st->opt_exec = FALSE; break; }
 				if (*optarg == 'u') { st->opt_personal_spaces = FALSE; break; }
+				if (*optarg == 'H') { st->opt_http_requests = FALSE; break; }
 				break;
 
 			case 'd': st->debug = TRUE; break;


### PR DESCRIPTION
I added option `-nH` to disable HTTP response to HTTP `GET` and `POST` requests.
A request starting with `GET` or `POST` will be handled like a normal Gopher selector.

This PR fixes issue #66.

I tested it by requesting the autogenerated `caps.txt` file.

Without `-nH`, the file is served:
```
$ ./src/gophernicus -r ./.travis/ <<EOF
GET /caps.txt
EOF

CAPS

##
## This is an automatically generated caps file.
##

CapsVersion=1
ExpireCapsAfter=1800
...
```

With `-nH`, we get an error.
```
$ ./src/gophernicus -nH -nf ./.travis/ <<EOF
GET /caps.txt
EOF

Error: File or directory not found! No such file or directory
```

