### PR TITLE
Always close file pointer and propagate CFLAGS/LDFLAGS to recursive MAKE calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,12 +46,12 @@ IPCRM   = /usr/bin/ipcrm
 all:
 	@case $$(uname) in \
 		Darwin)	$(MAKE) ROOT="$(OSXROOT)" DESTDIR="$(OSXDIr)" src/$(BINARY); ;; \
-		Haiku)	$(MAKE) LDFLAGS="-lnetwork" src/$(BINARY); ;; \
+		Haiku)	$(MAKE) LDFLAGS="$(LDFLAGS) -lnetwork" src/$(BINARY); ;; \
 		*)	if [ -f "/usr/include/tcpd.h" ]; then $(MAKE) withwrap; else $(MAKE) src/$(BINARY); fi; ;; \
 	esac
 
 withwrap:
-	$(MAKE) CFLAGS="-DHAVE_LIBWRAP" LDFLAGS="-lwrap" src/$(BINARY)
+	$(MAKE) CFLAGS="$(CFLAGS) -DHAVE_LIBWRAP" LDFLAGS="$(LDFLAGS) -lwrap" src/$(BINARY)
 
 deb:
 	dpkg-buildpackage -rfakeroot -uc -us

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ src/functions.h:
 	grep -h "^[a-z]" $(SOURCES) | \
 		grep -v "int main" | \
 		grep -v "strlc" | \
-		grep -v "[a-z]:" | \
+		grep -vi "[a-z]:" | \
 		sed -e "s/ =.*$$//" -e "s/ *$$/;/" >> $@
 	@echo
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -283,6 +283,7 @@ int gophermap(state *st, char *mapfile, int depth)
 	char type;
 	int port;
 	int exe;
+	int return_val = QUIT;
 
 	/* Prevent include loops */
 	if (depth > 4) return OK;
@@ -343,8 +344,13 @@ int gophermap(state *st, char *mapfile, int depth)
 		if (type == '#') continue;
 
 		/* Stop handling gophermap? */
-		if (type == '*') return OK;
-		if (type == '.') return QUIT;
+		if (type == '*') {
+			return_val = OK;
+			goto CLOSE_FP;
+		}
+		if (type == '.')
+			goto CLOSE_FP;
+
 
 		/* Print a list of users with public_gopher */
 		if (type == '~' && st->opt_personal_spaces) {
@@ -435,14 +441,14 @@ int gophermap(state *st, char *mapfile, int depth)
 		}
 	}
 
-	/* Clean up & return */
+CLOSE_FP:
 #ifdef HAVE_POPEN
 	if (exe & st->opt_exec) pclose(fp);
 	else
 #endif
 		fclose(fp);
 
-	return QUIT;
+	return return_val;
 }
 
 


### PR DESCRIPTION
This PR fixes a potential resource leak, where the file pointer to the gophermap is not `pclose`d or `fclose`d if the first character of the line is a `*` or a `.`.
`fopen` calls `malloc`, so some memory is leaked if `fclose` is not called.

Without the patch:
```$ make -B
$ cat >gophermap <<EOF
*
EOF
$ valgrind --show-leak-kinds=all --leak-check=full -s ./src/gophernicus -nf -r . <<EOF

EOF
==18015== Memcheck, a memory error detector
==18015== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18015== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==18015== Command: ./src/gophernicus -nf -r .
==18015== 
0install-sh                            2020-Apr-01 23:09    13.4 KB	/install-sh	doriath	70
.
==18015== 
==18015== HEAP SUMMARY:
==18015==     in use at exit: 488 bytes in 1 blocks
==18015==   total heap usage: 23 allocs, 22 frees, 62,597 bytes allocated
==18015== 
==18015== 488 bytes in 1 blocks are still reachable in loss record 1 of 1
==18015==    at 0x483A7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==18015==    by 0x48FF9FD: __fopen_internal (iofopen.c:65)
==18015==    by 0x48FF9FD: fopen@@GLIBC_2.2.5 (iofopen.c:86)
==18015==    by 0x10FFC1: gophermap (in /home/augfab/src/gopher/gophernicus/src/gophernicus)
==18015==    by 0x110504: gopher_menu (in /home/augfab/src/gopher/gophernicus/src/gophernicus)
==18015==    by 0x10DB1B: main (in /home/augfab/src/gopher/gophernicus/src/gophernicus)
==18015== 
==18015== LEAK SUMMARY:
==18015==    definitely lost: 0 bytes in 0 blocks
==18015==    indirectly lost: 0 bytes in 0 blocks
==18015==      possibly lost: 0 bytes in 0 blocks
==18015==    still reachable: 488 bytes in 1 blocks
==18015==         suppressed: 0 bytes in 0 blocks
==18015== 
==18015== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```

With the patch:
```
$ valgrind --show-leak-kinds=all --leak-check=full -s ./src/gophernicus -nf -r . <<EOF

EOF
==18142== Memcheck, a memory error detector
==18142== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==18142== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==18142== Command: ./src/gophernicus -nf -r .
==18142== 
0install-sh                            2020-Apr-01 23:09    13.4 KB	/install-sh	doriath	70
.
==18142== 
==18142== HEAP SUMMARY:
==18142==     in use at exit: 0 bytes in 0 blocks
==18142==   total heap usage: 23 allocs, 23 frees, 62,597 bytes allocated
==18142== 
==18142== All heap blocks were freed -- no leaks are possible
==18142== 
==18142== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```


I also noticed that the `CFLAGS` and `LDFLAGS` are not propagated correctly during recursive calls to `make`, for instance for `withwrap`.