### PR TITLE
Replace spurious tabs in menu with dashes (#81)

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -659,7 +659,7 @@ void gopher_menu(state *st)
 				n = width - strcut(displayname, width);
 				strrepeat(buf, ' ', n);
 
-				printf("1%s%s   %s		-  \t%s%s/\t%s\t%i" CRLF,
+				printf("1%s%s   %s   --------\t%s%s/\t%s\t%i" CRLF,
 					displayname,
 					buf,
 					timestr,


### PR DESCRIPTION
I searched for other leftover tabs with
```bash
$ git grep $'[^\t]\t'
```
and it seems like these were the last harmful ones.