### PR TITLE
Don't use DESTDIR for binary paths in listener

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -145,15 +145,15 @@ install-root:
 	$(INSTALL) -m 644 $(MAP).sample $(DESTDIR)$(ROOT)/gophermap
 
 install-inetd-update: install-root
-	update-inetd --add "$$(sed -e "s:@BINARY_PATH@:$(DESTDIR)$(SBINDIR)/$(BINARY):g" -e "s/@OPTIONS@/$(INETOPT)/g" init/inetlin.in)"
+	update-inetd --add "$$(sed -e "s:@BINARY_PATH@:$(SBINDIR)/$(BINARY):g" -e "s/@OPTIONS@/$(INETOPT)/g" init/inetlin.in)"
 	update-inetd --enable gopher
 
 install-inetd-manual: install-root
-	sed -e "s:@BINARY_PATH@:$(DESTDIR)$(SBINDIR)/$(BINARY):g" -e "s/@OPTIONS@/$(INETOPT)/g" init/inetlin.in >> $(DESTDIR)$(INETD)
+	sed -e "s:@BINARY_PATH@:$(SBINDIR)/$(BINARY):g" -e "s/@OPTIONS@/$(INETOPT)/g" init/inetlin.in >> $(DESTDIR)$(INETD)
 
 install-xinetd: install-root
 	$(INSTALL) -d -m 755 $(DESTDIR)/etc/xinetd.d
-	sed -i -e "s:@BINARY@:$(DESTDIR)$(SBINDIR)/$(BINARY):g" init/$(NAME).xinetd
+	sed -i -e "s:@BINARY@:$(SBINDIR)/$(BINARY):g" init/$(NAME).xinetd
 	$(INSTALL) -m 644 -T init/$(NAME).xinetd $(DESTDIR)$(XINETD)
 
 install-osx: install-root
@@ -172,7 +172,7 @@ install-systemd: install-root
 	$(INSTALL) -m 644 -T init/$(NAME).env $(DESTDIR)$(DEFAULT)/$(NAME)
 	$(INSTALL) -d -m 755 $(DESTDIR)$(SYSTEMD)
 	$(INSTALL) -m 644 -t $(DESTDIR)$(SYSTEMD) init/$(NAME).socket
-	sed -i -e "s:@BINARY@:$(DESTDIR)$(SBINDIR)/$(BINARY):g" init/$(NAME)\@.service
+	sed -i -e "s:@BINARY@:$(SBINDIR)/$(BINARY):g" init/$(NAME)\@.service
 	$(INSTALL) -m 644 -t $(DESTDIR)$(SYSTEMD) init/$(NAME)\@.service
 
 uninstall: @UNINSTALL_INETD_UPDATE@ @UNINSTALL_INETD_MANUAL@ @UNINSTALL_XINETD@ @UNINSTALL_OSX@ @UNINSTALL_SYSTEMD@


### PR DESCRIPTION
DESTDIR when used in packaging can represent a temporary directory or fake root used for packaging the application, so using this value for modifying the listener config is not ideal, as the binary path will be incorrect in the resulting package.

This change is to update `Makefile.in` to remove `DESTDIR` from the `sed` calls, as `SBINDIR` should be enough to provide the full path for the binary.

