### PR TITLE
Really check success of getcwd(3)

### DIFF
--- a/src/gophernicus.c
+++ b/src/gophernicus.c
@@ -529,8 +529,8 @@ int main(int argc, char *argv[])
 
 	/* Convert relative gopher roots to absolute roots */
 	if (st.server_root[0] != '/') {
-		char cwd[512];
-		getcwd(cwd, sizeof(cwd));
+		char cwd_buf[512];
+		const char *cwd = getcwd(cwd_buf, sizeof(cwd_buf));
 		if (cwd == NULL) {
 			die(&st, NULL, "unable to get current path");
 		}


### PR DESCRIPTION
`getcwd(3)` returns a `NULL` pointer when it fails, and a pointer to the buffer
when it succeeds. The array of characters (allocated on the stack) is not `NULL`,
so it cannot be used to check if `getcwd(3)` succeeded. Use the pointer
returned by `getcwd(3)` to check success.

This bug was found by Clang 12 (`-Wtautological-pointer-compare`).