### PR TITLE
some manpage fixes

### DIFF
--- a/gophernicus.8
+++ b/gophernicus.8
@@ -66,21 +66,17 @@ Changes the server hostname shown on the output menu.
 The default is the fully qualified domain name of the machine.
 .It Fl p Ar port
 Changes the server port shown on the output menu.
-The default is
-.Pa 70 .
+The default is 70.
 .It Fl T Ar port
 Changes the SSL/TLS port.
-The default is
-.Pa 0
-(disabled).
+The default is 0 (disabled).
 .It Fl r Ar directory
 Set the document root of the server.
 The default is
 .Pa /var/gopher .
 .It Fl t Ar type
 Set the default gopher filetype.
-The default is
-.Pa 0 .
+The default is 0.
 .It Fl g Ar mapfile
 Set the gophermap file name.
 The default is
@@ -96,19 +92,18 @@ The default is
 .It Fl u Ar directory
 Set the name of the personal gopherspace directory.
 Each user can deploy a personal gopherspace by creating a directory
-.Pa directory
+.Ar directory
 in their home directory.
 The default is
 .Pa public_gopher .
 .It Fl l Ar file
 Log to
-.Pa file
+.Ar file
 in Apache-compatible combined format.
 Disabled by default.
 .It Fl w Ar width
 Set default page width.
-The default is
-.Pa 67 .
+The default is 67.
 .It Fl o Ar charset
 Select the output charset.
 It can be one of
@@ -120,17 +115,13 @@ The default is
 .Ar UTF-8 .
 .It Fl s Ar seconds
 Session timeout in seconds.
-The default is
-.Pa 1800 .
+The default is 1800.
 .It Fl i Ar hits
 Maximum hits until throttling.
-The default is
-.Pa 4069 .
+The default is 4069.
 .It Fl k Ar kilobytes
 Maximum transfer size in KiB until throttling.
-The default is
-.Pa 4194304
-(4 GiB).
+The default is 4194304 (4 GiB).
 .It Fl f Ar directory
 Set directory where output filters are found.
 Disabled by default.

--- a/gophernicus.8
+++ b/gophernicus.8
@@ -91,7 +91,7 @@ The default is
 .Pa /cgi-bin/ .
 .It Fl u Ar directory
 Set the name of the personal gopherspace directory.
-Each user can deploy a personal gopherspace by creating a directory
+Each user can deploy a personal gopherspace by creating
 .Ar directory
 in their home directory.
 The default is

--- a/gophernicus.8
+++ b/gophernicus.8
@@ -193,6 +193,8 @@ By default,
 will refuse to run as root.
 .It Fl np
 Disable HAProxy proxy protocol.
+.It Fl nu
+Disable personal gopherspaces.
 .It Fl nx
 Disable execution of gophermaps and scripts.
 .It Fl nH

--- a/gophernicus.8
+++ b/gophernicus.8
@@ -1,5 +1,5 @@
 .Dd April 13, 2020
-.Dt GOPHERNICUS 1
+.Dt GOPHERNICUS 8
 .Os
 .Sh NAME
 .Nm gophernicus
@@ -47,11 +47,12 @@
 .Op Fl \&?
 .Sh DESCRIPTION
 .Nm
-is a gopher server. It serves almost compliant RFC 1436, with small
-changes to make it more modern.
+is a gopher server.
+It serves almost compliant RFC 1436, with small changes to make it more
+modern.
 .Nm
-supports userdirs, executable gophermaps, CGI, and virtual hosting (in the
-limits of the RFC).
+supports userdirs, executable gophermaps, CGI, and virtual hosting
+.Pq in the limits of the RFC .
 .Pp
 .Nm
 can log to
@@ -102,13 +103,15 @@ The default is
 .It Fl l Ar file
 Log to
 .Pa file
-in Apache-compatible combined format. Disabled by default.
+in Apache-compatible combined format.
+Disabled by default.
 .It Fl w Ar width
 Set default page width.
 The default is
 .Pa 67 .
 .It Fl o Ar charset
-Select the output charset. It can be
+Select the output charset.
+It can be one of
 .Ar UTF-8 ,
 .Ar US-ASCII ,
 or
@@ -156,7 +159,8 @@ Set the email of the administrator to appear in
 .It Fl U Ar paths
 Set a colon-separated list of extra
 .Xr unveil 2
-paths (only for OpenBSD).
+paths
+.Pq only for Ox .
 .It Fl nv
 Disable virtual hosting.
 .It Fl nl
@@ -225,7 +229,7 @@ mostly conforms to
 .Lk https://tools.ietf.org/html/rfc1436 "RFC 1436"
 .Sh AUTHORS
 .An -nosplit
-.An Kim Holviala.
+.An Kim Holviala
 wrote the original implementation (2009\(en2018).
 .Pp
 .An fosslinux
@@ -249,7 +253,7 @@ Copyright \(co
 2009\(en2018.
 .Pp
 Copyright \(co
-.An Nm gophernicus Ns \& developers
+.An gophernicus developers
 2019.
 .Pp
 Licensed to you under the terms of the BSD 2-clause license.


### PR DESCRIPTION
This fixes a couple of issue with the current manpage:

 - document `-nu` (it's only present in the SYNOPSIS)
 - fix every issue reported by `man -Tlint -l gophernicus.8` *
 - fix the usage of the `Pa` macro


\* mandoc still complains about:

```
man: gophernicus.8:1:5: STYLE: Mdocdate missing: Dd April 13, 2020 (OpenBSD)
man: gophernicus.8: STYLE: RCS id missing: (OpenBSD)
```

but those are only relevant for the OpenBSD manpages, not third parties ones.