### PR TITLE
tightens pledge(2) promises

### DIFF
--- a/src/gophernicus.c
+++ b/src/gophernicus.c
@@ -539,6 +539,13 @@ int main(int argc, char *argv[])
 		sstrlcpy(st.server_root, buf);
 	}
 
+	/* Check if TCP wrappers have something to say about this connection */
+#ifdef HAVE_LIBWRAP
+	if (sstrncmp(st.req_remote_addr, UNKNOWN_ADDR) != MATCH &&
+		hosts_ctl(self, STRING_UNKNOWN, st.req_remote_addr, STRING_UNKNOWN) == WRAP_DENIED)
+		die(&st, ERR_ACCESS, "Refused connection");
+#endif
+
 #ifdef __OpenBSD__
 	/* unveil(2) support.
 	 *
@@ -604,13 +611,6 @@ int main(int argc, char *argv[])
 		if (pledge(pledges, NULL) == -1)
 			die(&st, "pledge", pledges);
 	}
-#endif
-
-	/* Check if TCP wrappers have something to say about this connection */
-#ifdef HAVE_LIBWRAP
-	if (sstrncmp(st.req_remote_addr, UNKNOWN_ADDR) != MATCH &&
-		hosts_ctl(self, STRING_UNKNOWN, st.req_remote_addr, STRING_UNKNOWN) == WRAP_DENIED)
-		die(&st, ERR_ACCESS, "Refused connection");
 #endif
 
 	/* Make sure the computer is turned on */

--- a/src/gophernicus.c
+++ b/src/gophernicus.c
@@ -587,14 +587,12 @@ int main(int argc, char *argv[])
 		/* pledge(2) never allows shared memory */
 		log_debug("shared-memory enabled, can't pledge(2)");
 	} else {
-		strlcpy(pledges,
-				"stdio rpath inet sendfd recvfd proc",
-				sizeof(pledges));
+		strlcpy(pledges, "stdio rpath", sizeof(pledges));
 
 		/* Executable maps shell-out using popen(3) */
 		if (st.opt_exec) {
-			strlcat(pledges, " exec", sizeof(pledges));
-			log_debug("executable gophermaps enabled, adding `exec' to pledge(2)");
+			strlcat(pledges, " proc exec", sizeof(pledges));
+			log_debug("executable gophermaps enabled, adding `proc exec' to pledge(2)");
 		}
 
 		/* Personal spaces require getpwnam(3) and getpwent(3) */


### PR DESCRIPTION
* `sendfd` and `recvfd` are not needed: gophernicus doesn't use sendmsg(2) nor recvmsg(2).
* `inet` its needed only for getpeername(2), but it's only called from init_state and is *before* pledging.
* `proc` is needed only when st.opt_exec is set.

I have only one doubt about `sendfd` and `recvfd`: those *may* be used by libwrap, but that's not available on OpenBSD anyway.  (a quick grep doesn't find anything in the libwrap sources, but I haven't studied it in depth.)