### PR TITLE
Suppress stderr output when checking for install

### DIFF
--- a/configure
+++ b/configure
@@ -113,9 +113,9 @@ else
     # Check it has required features (*cough* macos)
     mkdir testconf
     touch testfile
-    ${INSTALL} -t testconf testfile 2>&1 >/dev/null || INSTALL=build-aux/install-sh
+    ${INSTALL} -t testconf testfile >/dev/null 2>&1 || INSTALL=build-aux/install-sh
     rm testconf/testfile
-    ${INSTALL} -T testfile testconf/testfile 2>&1 >/dev/null || INSTALL=build-aux/install-sh
+    ${INSTALL} -T testfile testconf/testfile >/dev/null 2>&1 || INSTALL=build-aux/install-sh
     rm -r testconf testfile
     printf "%s" "${INSTALL}"
 fi


### PR DESCRIPTION
When checking the features of the install program, send any output on stderr to /dev/null rather than to stdout.