### PR TITLE
Update menu.c: Fix JPEG detection.

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -264,7 +264,7 @@ char gopher_filetype(state *st, char *file, char magic)
 		sstrncmp(buf, "GIF87a") == MATCH) return TYPE_GIF;
 
 	/* JPEG images */
-	if (sstrncmp(buf, "\377\330\377\340") == MATCH) return TYPE_IMAGE;
+	if (sstrncmp(buf, "\377\330\377") == MATCH) return TYPE_IMAGE;
 
 	/* PNG images */
 	if (sstrncmp(buf, "\211PNG") == MATCH) return TYPE_IMAGE;


### PR DESCRIPTION
The existing JPEG detection logic is too restrictive because it checks for the file header "FF D8 FF E0", which only matches JFIF-type JPEG images... Meanwhile EXIF JPEG images are more common these days.

For reference:
FF D8 = JPEG SOI (Start of Image) header
FF-D8-FF-E0 = JFIF
FF-D8-FF-E1 = EXIF
FF-D8-FF-E2 = CIFF
FF-D8-FF-E8 = SPIFF

As you can see checking for the SOI + FF matches all extant types of JPEG images... Many implementations only check for the SOI, I think they are crazy. \o/