### PR TITLE
Update platform.c: Detect Alpine Linux properly.

### DIFF
--- a/src/platform.c
+++ b/src/platform.c
@@ -230,6 +230,14 @@ void platform(state *st)
 		}
 	}
 
+	/* Alpine Linux version should be in /etc/alpine-release */
+	if (!*release && (fp = fopen("/etc/alpine-release", "r"))) {
+		sstrlcpy(sysname, "Alpine Linux");
+		if (fgets (release, sizeof(release), fp) != NULL)
+			if ((c = strchr(release, '/'))) *c = '\0';
+		fclose(fp);
+	}
+		
 	/* OK, nothing worked - let's try /etc/issue for sysname */
 	if (!*sysname && (fp = fopen("/etc/issue", "r"))) {
 		if (fgets(sysname, sizeof(sysname), fp) != NULL) {


### PR DESCRIPTION
Gophernicus currently thinks that Alpine Linux is called "Welcome/6.7" (seems to be extracting the OS name from /etc/issue and the version it's grabbing the kernel version)

This commit allows gophernicus to read /etc/alpine-release and display the OS name and version correctly (e.g. "Alpine Linux/3.20")