### PR TITLE
Explicitly terminate dest string in html_encode

### DIFF
--- a/src/gophernicus.c
+++ b/src/gophernicus.c
@@ -127,6 +127,7 @@ void html_encode(const char *unsafe, char *dest, int bufsize)
 			i += 1;
 		}
 	}
+	dest[j] = '\0';
 }
 
 /*


### PR DESCRIPTION
This fixes an issue introduced in commit a00fa5330dd4. As the destination string produced by html_escape is not explicitly terminated by the function as introduced in this commit, the escaped URL in dest continues with characters found in memory that have not been overwritten, which essentially breaks the encoded URL. The behaviour prior to commit a00fa5330dd4 was as follows:

    $ src/gophernicus <<<URL:https://example.com | grep Refresh
      <META HTTP-EQUIV="Refresh" content="1;URL=https://example.com">

The broken behaviour since commit a00fa5330dd4 is this:

    $ src/gophernicus <<<URL:https://example.com | grep Refresh
      <META HTTP-EQUIV="Refresh" content="1;URL=https://example.comtps://example.com"">

Explicitly terminating the destination string by adding a zero byte seems to fix this; yet, since I am not a C programmer myself, I may well have missed some ramifications of this change. In any case, the output produced by gophernicus since commit a00fa5330dd4 is essentially broken, so this is probably still an improvement.