### PR TITLE
Add gemini:// to redirection whitelist

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -117,6 +117,7 @@ void url_redirect(state *st)
 
 	if (sstrncmp(dest, "http://") != MATCH &&
 		sstrncmp(dest, "https://") != MATCH &&
+		sstrncmp(dest, "gemini://") != MATCH &&
 		sstrncmp(dest, "ftp://") != MATCH &&
 		sstrncmp(dest, "irc://") != MATCH &&
 		sstrncmp(dest, "mailto:") != MATCH)


### PR DESCRIPTION
Gophernicus features a hard-coded whitelist of safe protocols that are allowed for html-based redirects. This list currently consists of http, https, ftp, irc and mailto. As the gemini protocol is seeing an ever greater usage, some phloggers have already started to add 'hURL:gemini://' links to their gophermaps. Since the current whitelist already seems to be somewhat permissive, I hereby suggest adding the gemini protocol to it.