### PR TITLE
Fix(build): Resolve GCC13 string warning in src/menu.c

### DIFF
--- a/src/menu.c
+++ b/src/menu.c
@@ -132,7 +132,7 @@ static void userlist(state *st)
 		if (dir.st_uid != pwd->pw_uid) continue;
 
 		/* Found one */
-		strcpy(users[i].user, pwd->pw_name);
+		strlcpy(users[i].user, pwd->pw_name, sizeof(users[i].user));strcpy(users[i].user, pwd->pw_name);
 		users[i].mtime = dir.st_mtime;
 		i++;
 	}
@@ -158,6 +158,8 @@ static void userlist(state *st)
 
 			printf("1%-*.*s   %s        -  \t/~%s/\t%s\t%i" CRLF,
 			    width, width, buf, timestr, users[i].user,
+
+
 			    st->server_host, st->server_port);
 		}
 		else {


### PR DESCRIPTION
This patch resolves Issue #87. It replaces a deprecated strcpy() call in src/menu.c with the built-in, safe strlcpy() function, which resolves GCC 13 compiler warnings.
The patched binary was successfully compiled and runtime-tested (via socat) on the stable 3.1.1 tag.