### PR TITLE
Add -nD option to allow serving of dotfiles.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ are made.
     -np           Disable HAproxy proxy protocol
     -nx           Disable execution of gophermaps and scripts
     -nu           Disable personal gopherspaces
+    -nD           Enable serving dotfiles
 
     -d            Debug output in syslog and /server-status
     -v            Display version number and build date

--- a/gophernicus.8
+++ b/gophernicus.8
@@ -42,6 +42,7 @@
 .Op Fl nx
 .Op Fl nu
 .Op Fl nH
+.Op Fl nD
 .Op Fl d
 .Op Fl b
 .Op Fl \&?
@@ -194,6 +195,8 @@ Disable personal gopherspaces.
 Disable execution of gophermaps and scripts.
 .It Fl nH
 Disable HTTP response to HTTP GET and POST requests.
+.It Fl nD
+Enable serving dotfiles.
 .It Fl d
 Print debug output in
 .Xr syslog 3 .

--- a/src/gophernicus.c
+++ b/src/gophernicus.c
@@ -497,6 +497,7 @@ static void init_state(state *st)
 	st->opt_exec = TRUE;
 	st->opt_personal_spaces = TRUE;
 	st->opt_http_requests = TRUE;
+	st->opt_dotfile = FALSE;
 	st->debug = FALSE;
 
 	/* Load default suffix -> filetype mappings */
@@ -798,9 +799,11 @@ get_selector:
 	/* Remove encodings from selector */
 	strndecode(st.req_selector, st.req_selector, sizeof(st.req_selector));
 
-	/* Deny requests for Slashdot and /../ hackers */
-	if (strstr(st.req_selector, "/."))
-		die(&st, ERR_ACCESS, "Refusing to serve out dotfiles");
+	/* Deny requests for /../ hackers, deny dotfiles by default */
+	if (!st.opt_dotfile && strstr(st.req_selector, "/.")) {
+		die(&st, ERR_ACCESS, "Refusing to serve out dotfiles"); }
+	if (st.opt_dotfile && strstr(st.req_selector, "/..")) {
+		die(&st, ERR_ACCESS, "Refusing directory traversal"); }
 
 	/* Handle /server-status requests */
 #ifdef HAVE_SHMEM

--- a/src/gophernicus.h
+++ b/src/gophernicus.h
@@ -373,6 +373,7 @@ typedef struct {
     char opt_exec;
     char opt_personal_spaces;
     char opt_http_requests;
+	char opt_dotfile;
     char debug;
 } state;
 

--- a/src/menu.c
+++ b/src/menu.c
@@ -586,8 +586,16 @@ void gopher_menu(state *st)
 		snprintf(pathname, sizeof(pathname), "%s/%s",
 			st->req_realpath, dir[i].name);
 
-		/* Skip dotfiles and non world-readables */
-		if (dir[i].name[0] == '.') continue;
+		/* Skip dotfiles */
+		if (!st->opt_dotfile) {
+			if (dir[i].name[0] == '.') continue; }
+		/* Unless the user wants them; but don't generate menu entries for the literal */
+		/* "." and ".." files/directories; they are not useful in this context */
+		else {
+			if (strcmp(dir[i].name, ".\0") == MATCH ) { continue; }
+			if (strcmp(dir[i].name, "..\0") == MATCH ) { continue; }
+		}
+		/* Skip non world-readables */
 		if ((dir[i].mode & S_IROTH) == 0) continue;
 
 		/* Skip gophermaps and tags (but not dirs) */

--- a/src/options.c
+++ b/src/options.c
@@ -158,6 +158,7 @@ void parse_args(state *st, int argc, char *argv[])
 				if (*optarg == 'x') { st->opt_exec = FALSE; break; }
 				if (*optarg == 'u') { st->opt_personal_spaces = FALSE; break; }
 				if (*optarg == 'H') { st->opt_http_requests = FALSE; break; }
+				if (*optarg == 'D') { st->opt_dotfile = TRUE; break; }
 				break;
 
 			case 'd': st->debug = TRUE; break;


### PR DESCRIPTION
Currently gophernicus will not serve dotfiles. This PR intends to expose a new command line flag ```-nD``` to enable users to serve these files if they so desire. This will also enable dotfiles in generated directory listings.

Requests containing ".." will still be blocked. Directory listings will not generate entries for "." or ".."

Resolves issue #99 

Testing is appreciated. Please apply the fix in PR #139 too in order to test off of the master branch,